### PR TITLE
Add Image-Based Continuous Integration

### DIFF
--- a/.github/workflows/on_pr_build_push_vet_images.yml
+++ b/.github/workflows/on_pr_build_push_vet_images.yml
@@ -1,0 +1,150 @@
+name: On PR Build Push Vet
+
+on:
+  pull_request:
+    branches:
+      - main
+
+env:
+  BRANCH: ${{ github.head_ref }}
+  COMMIT: ${{ github.event.pull_request.head.sha }}
+
+# Possibly produced images
+  #             owner/repository_branch:commitsha
+  VETTED_IMAGE: brianjbayer/samplecsharpxunitselenium_${{ github.head_ref }}:${{ github.event.pull_request.head.sha }}
+
+  #               owner/repository_branch_unvetted:commitsha
+  UNVETTED_IMAGE: brianjbayer/samplecsharpxunitselenium_${{ github.head_ref }}_unvetted:${{ github.event.pull_request.head.sha }}
+
+  #             owner/repository_branch_dev:commitsha
+  DEVENV_IMAGE: brianjbayer/samplecsharpxunitselenium_${{ github.head_ref }}_dev:${{ github.event.pull_request.head.sha }}
+
+jobs:
+
+  # Build and Push Images
+  build-and-push-branch-devenv:
+    uses: brianjbayer/actions-image-cicd/.github/workflows/build_push_image.yml@main
+    with:
+      image: brianjbayer/samplecsharpxunitselenium_${{ github.head_ref }}_dev:${{ github.event.pull_request.head.sha }}
+      buildopts: --target devenv
+    secrets:
+      registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
+      registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+  build-and-push-branch-unvetted:
+    uses: brianjbayer/actions-image-cicd/.github/workflows/build_push_image.yml@main
+    with:
+      image: brianjbayer/samplecsharpxunitselenium_${{ github.head_ref }}_unvetted:${{ github.event.pull_request.head.sha }}
+    secrets:
+      registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
+      registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+  # Vet Deploy Image
+  vet-code-standards:
+    needs: build-and-push-branch-devenv
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: dockercomposerun linting on development environment
+        run: "BROWSERTESTS_IMAGE=${DEVENV_IMAGE} ./SampleCSharpXunitSelenium/script/dockercomposerun -n -d ./SampleCSharpXunitSelenium/script/runlint"
+
+  vet-dependency-security:
+    needs: build-and-push-branch-devenv
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: dockercomposerun security scan on development environment
+        run: "BROWSERTESTS_IMAGE=${DEVENV_IMAGE} ./SampleCSharpXunitSelenium/script/dockercomposerun -n -d ./SampleCSharpXunitSelenium/script/runsecscan"
+
+  vet-e2e-tests-deploy-image-default-chrome:
+    needs: build-and-push-branch-unvetted
+    runs-on: ubuntu-latest
+    env:
+      ValidLoginUser: ${{ secrets.ValidLoginUser }}
+      ValidLoginPass: ${{ secrets.ValidLoginPass }}
+    steps:
+      - uses: actions/checkout@v1
+      - name: dockercomposerun unvetted image
+        run: "BROWSERTESTS_IMAGE=${UNVETTED_IMAGE} ./SampleCSharpXunitSelenium/script/dockercomposerun -c"
+
+  vet-e2e-tests-deploy-image-firefox:
+    needs: build-and-push-branch-unvetted
+    runs-on: ubuntu-latest
+    env:
+      Browser: firefox
+      SELENIUM_IMAGE: selenium/standalone-firefox:latest
+      ValidLoginUser: ${{ secrets.ValidLoginUser }}
+      ValidLoginPass: ${{ secrets.ValidLoginPass }}
+    steps:
+      - uses: actions/checkout@v1
+      - name: dockercomposerun unvetted image
+        run: "BROWSERTESTS_IMAGE=${UNVETTED_IMAGE} ./SampleCSharpXunitSelenium/script/dockercomposerun -c"
+
+  vet-e2e-tests-deploy-image-edge:
+    needs: build-and-push-branch-unvetted
+    runs-on: ubuntu-latest
+    env:
+      Browser: edge
+      SELENIUM_IMAGE: selenium/standalone-edge:latest
+      ValidLoginUser: ${{ secrets.ValidLoginUser }}
+      ValidLoginPass: ${{ secrets.ValidLoginPass }}
+    steps:
+      - uses: actions/checkout@v1
+      - name: dockercomposerun unvetted image
+        run: "BROWSERTESTS_IMAGE=${UNVETTED_IMAGE} ./SampleCSharpXunitSelenium/script/dockercomposerun -c"
+
+# Push (IF) Vetted Deploy Image
+  push-branch-vetted-deploy-image:
+    needs:
+      - vet-code-standards
+      - vet-dependency-security
+      - vet-e2e-tests-deploy-image-default-chrome
+      - vet-e2e-tests-deploy-image-firefox
+      - vet-e2e-tests-deploy-image-edge
+    uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_image.yml@main
+    with:
+      # Pull unvetted branch image
+      pull_as: brianjbayer/samplecsharpxunitselenium_${{ github.head_ref }}_unvetted:${{ github.event.pull_request.head.sha }}
+      # Push Vetted Image
+      push_as: brianjbayer/samplecsharpxunitselenium_${{ github.head_ref }}:${{ github.event.pull_request.head.sha }}
+    secrets:
+      registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
+      registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+  # Vet Dev Environment Image
+  vet-e2e-tests-devenv-image-default-chrome:
+    needs: build-and-push-branch-devenv
+    runs-on: ubuntu-latest
+    env:
+      ValidLoginUser: ${{ secrets.ValidLoginUser }}
+      ValidLoginPass: ${{ secrets.ValidLoginPass }}
+    steps:
+      - uses: actions/checkout@v1
+      - name: dockercomposerun devenv image
+        run: "BROWSERTESTS_IMAGE=${DEVENV_IMAGE} ./SampleCSharpXunitSelenium/script/dockercomposerun -d ./SampleCSharpXunitSelenium/script/runtests"
+
+  vet-e2e-tests-devenv-image-firefox:
+    needs: build-and-push-branch-devenv
+    runs-on: ubuntu-latest
+    env:
+      Browser: firefox
+      SELENIUM_IMAGE: selenium/standalone-firefox:latest
+      ValidLoginUser: ${{ secrets.ValidLoginUser }}
+      ValidLoginPass: ${{ secrets.ValidLoginPass }}
+    steps:
+      - uses: actions/checkout@v1
+      - name: dockercomposerun devenv image
+        run: "BROWSERTESTS_IMAGE=${DEVENV_IMAGE} ./SampleCSharpXunitSelenium/script/dockercomposerun -d ./SampleCSharpXunitSelenium/script/runtests"
+
+  vet-e2e-tests-devenv-image-edge:
+    needs: build-and-push-branch-devenv
+    runs-on: ubuntu-latest
+    env:
+      Browser: edge
+      SELENIUM_IMAGE: selenium/standalone-edge:latest
+      ValidLoginUser: ${{ secrets.ValidLoginUser }}
+      ValidLoginPass: ${{ secrets.ValidLoginPass }}
+    steps:
+      - uses: actions/checkout@v1
+      - name: dockercomposerun devenv image
+        run: "BROWSERTESTS_IMAGE=${DEVENV_IMAGE} ./SampleCSharpXunitSelenium/script/dockercomposerun -d ./SampleCSharpXunitSelenium/script/runtests"

--- a/.github/workflows/on_push_to_main_promote_to_prod.yml
+++ b/.github/workflows/on_push_to_main_promote_to_prod.yml
@@ -1,0 +1,66 @@
+name: On Merge Promote Branch Image to Prod
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+
+  branch-and-last-commit:
+    uses: brianjbayer/actions-image-cicd/.github/workflows/get_merged_branch_last_commit.yml@main
+
+  branch-and-last-commit-merged-info:
+    needs: [branch-and-last-commit]
+    runs-on: ubuntu-latest
+    env:
+      BRANCH_LAST_COMMIT: ${{ needs.branch-and-last-commit.outputs.commit }}
+      BRANCH: ${{ needs.branch-and-last-commit.outputs.branch }}
+    steps:
+      - name: Output last commit of merged branch env var
+        run: echo "BRANCH_LAST_COMMIT=[${BRANCH_LAST_COMMIT}]"
+      - name: Output merged branch env var
+        run: echo "BRANCH=[${BRANCH}]"
+
+  promote-branch-last-commit-to-prod:
+    needs: [branch-and-last-commit]
+    uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_image.yml@main
+    with:
+      # Pull last (vetted) branch image
+      pull_as: brianjbayer/samplecsharpxunitselenium_${{ needs.branch-and-last-commit.outputs.branch }}:${{ needs.branch-and-last-commit.outputs.commit }}
+      # Push prod Image
+      push_as: brianjbayer/samplecsharpxunitselenium:${{ needs.branch-and-last-commit.outputs.commit }}
+    secrets:
+      registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
+      registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+  promote-branch-last-commit-to-prod-latest:
+    needs: [branch-and-last-commit, promote-branch-last-commit-to-prod]
+    uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_latest_image.yml@main
+    with:
+      image_name: brianjbayer/samplecsharpxunitselenium
+      image_tag: ${{ needs.branch-and-last-commit.outputs.commit }}
+    secrets:
+      registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
+      registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+  promote-branch-last-commit-devenv:
+    needs: [branch-and-last-commit]
+    uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_image.yml@main
+    with:
+      # Pull last branch devenv image
+      pull_as: brianjbayer/samplecsharpxunitselenium_${{ needs.branch-and-last-commit.outputs.branch }}_dev:${{ needs.branch-and-last-commit.outputs.commit }}
+      # Push prod devenv image
+      push_as: brianjbayer/samplecsharpxunitselenium-dev:${{ needs.branch-and-last-commit.outputs.commit }}
+    secrets:
+      registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
+      registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+  promote-branch-last-commit-devenv-to-latest:
+    needs: [branch-and-last-commit, promote-branch-last-commit-devenv]
+    uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_latest_image.yml@main
+    with:
+      image_name: brianjbayer/samplecsharpxunitselenium-dev
+      image_tag: ${{ needs.branch-and-last-commit.outputs.commit }}
+    secrets:
+      registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
+      registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}


### PR DESCRIPTION
# What
This adds image-based Continuous Integration (CI) using (reusable) GitHub Actions.

> Note that because Docker Hub only allows lowercase image repository names and this source code repository's name uses CamelCase, the actions files needed to be modified to hard-code the image repository name.

# Why
This CI vets code quality and produces ready-to-use images for this project. 

# Change Impact Analysis and Testing
The PR CI has been tested with the commits of this PR.  No way to test the modified on merge action.  Fingers-crossed.
