### PR TITLE
Add explicit update PackageReference for Newtonsoft.Json and update other packages

### DIFF
--- a/SampleCSharpXunitSelenium/SampleCSharpXunitSelenium.csproj
+++ b/SampleCSharpXunitSelenium/SampleCSharpXunitSelenium.csproj
@@ -5,20 +5,21 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0"/>
-    <PackageReference Include="xunit" Version="2.4.1"/>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1"/>
+    <PackageReference Include="xunit" Version="2.4.2"/>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0"/>
-    <PackageReference Include="FluentAssertions" Version="6.6.0"/>
-    <PackageReference Include="Selenium.WebDriver" Version="4.1.1"/>
-    <PackageReference Include="Selenium.Support" Version="4.1.1"/>
-    <PackageReference Include="WebDriverManager" Version="2.12.4" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0"/>
+    <PackageReference Include="Selenium.WebDriver" Version="4.3.0"/>
+    <PackageReference Include="Selenium.Support" Version="4.3.0"/>
+    <PackageReference Include="WebDriverManager" Version="2.15.0" />
     <!-- The following are transitive packages explicitly included to avoid transitive CVEs   -->
     <!-- Ideally these should be removed if/when the transitive vulnerabilities are addressed -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>


### PR DESCRIPTION
# What

Encountered this security vulnerability on development.

- Updated packages when available.  
- Added explicit package reference for `Newtonsoft.Json ` and forced update. 

Update for security vulnerability...
```
Transitive Package      Resolved   Severity   Advisory URL                                     
   > Newtonsoft.Json       12.0.3     High       https://github.com/advisories/GHSA-5crp-9r3c-p9vr
```

# Why
Security vulnerability.

# Change Impact Analysis and Testing

- [ ] Checks will fail if not fixed
- [ ] Tested local browsers

