### PR TITLE
Update to .NET 7 and Update Packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base Image is the builder stage since it is an SDK
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS builder
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS builder
 
 # Dev Environment Stage
 FROM builder AS devenv

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ the tests either can be run directly by the
 or by the supplied `runtests` script.
 
 ### Prerequisites
-* .NET 6 SDK
+* .NET 7 SDK
 * To run the tests using a specific browser requires that browser
   be installed (e.g. to run the tests in the Chrome Browser requires
   Chrome be installed).

--- a/SampleCSharpXunitSelenium/SampleCSharpXunitSelenium.csproj
+++ b/SampleCSharpXunitSelenium/SampleCSharpXunitSelenium.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
@@ -11,8 +11,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <PackageReference Include="FluentAssertions" Version="6.7.0"/>
     <PackageReference Include="Selenium.WebDriver" Version="4.3.0"/>
     <PackageReference Include="Selenium.Support" Version="4.3.0"/>

--- a/SampleCSharpXunitSelenium/SampleCSharpXunitSelenium.csproj
+++ b/SampleCSharpXunitSelenium/SampleCSharpXunitSelenium.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
     <PackageReference Include="xunit" Version="2.4.2"/>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -13,13 +13,13 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-    <PackageReference Include="FluentAssertions" Version="6.7.0"/>
-    <PackageReference Include="Selenium.WebDriver" Version="4.3.0"/>
-    <PackageReference Include="Selenium.Support" Version="4.3.0"/>
-    <PackageReference Include="WebDriverManager" Version="2.15.0" />
+    <PackageReference Include="FluentAssertions" Version="6.8.0"/>
+    <PackageReference Include="Selenium.WebDriver" Version="4.7.0"/>
+    <PackageReference Include="Selenium.Support" Version="4.7.0"/>
+    <PackageReference Include="WebDriverManager" Version="2.16.2" />
     <!-- The following are transitive packages explicitly included to avoid transitive CVEs   -->
     <!-- Ideally these should be removed if/when the transitive vulnerabilities are addressed -->
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <!-- <PackageReference Include="Newtonsoft.Json" Version="13.0.1" /> -->
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>


### PR DESCRIPTION
# What
This changeset updates this project to .NET 7 from .NET 6.  It also updates project packages when applicable.  There are no changes to functionality expected with this changeset.

# Why
This update maintains currency which should reduce future update risks and effort.

# Change Impact Analysis and Testing
This changeset only updates the .NET SDK and some packages.

- [x] CI will vet building and operating the deployment and development containers
- [x] CI will vet static security scanning of packages
- [x] CI will vet the functionality of the deployment and development containers ensuring no regressions
- [x] Manual native execution of the tests with supported browsers will mitigate regressions when running natively locally 
