### PR TITLE
Add Support for Apple Silicon Images (i.e. `linux/arm64`)

### DIFF
--- a/.github/workflows/on_pr_build_push_vet_images.yml
+++ b/.github/workflows/on_pr_build_push_vet_images.yml
@@ -29,7 +29,7 @@ jobs:
   buildx-and-push-branch-devenv:
     needs: [pr-norm-branch]
     # TODO: Change to use main branch when buildx_push_image merged
-    uses: brianjbayer/actions-image-cicd/.github/workflows/buildx_push_image.yml@add-multi-arch-buildx
+    uses: brianjbayer/actions-image-cicd/.github/workflows/buildx_push_image.yml@main
     with:
       image: brianjbayer/samplecsharpxunitselenium_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}
       buildopts: --target devenv
@@ -41,7 +41,7 @@ jobs:
   buildx-and-push-branch-unvetted:
     needs: [pr-norm-branch]
     # TODO: Change to use main branch when buildx_push_image merged
-    uses: brianjbayer/actions-image-cicd/.github/workflows/buildx_push_image.yml@add-multi-arch-buildx
+    uses: brianjbayer/actions-image-cicd/.github/workflows/buildx_push_image.yml@main
     with:
       image: brianjbayer/samplecsharpxunitselenium_${{ needs.pr-norm-branch.outputs.name }}_unvetted:${{ github.event.pull_request.head.sha }}
       platforms: "linux/amd64,linux/arm64"
@@ -96,7 +96,7 @@ jobs:
       - vet-deploy-image-e2e-tests-matrix
       - pr-norm-branch
     # TODO: Change to use main branch when buildx_push_image merged
-    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@add-multi-arch-buildx
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@main
     with:
       source_image: brianjbayer/samplecsharpxunitselenium_${{ needs.pr-norm-branch.outputs.name }}_unvetted:${{ github.event.pull_request.head.sha }}
       target_image: brianjbayer/samplecsharpxunitselenium_${{ needs.pr-norm-branch.outputs.name }}:${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/on_push_to_main_promote_to_prod.yml
+++ b/.github/workflows/on_push_to_main_promote_to_prod.yml
@@ -33,7 +33,7 @@ jobs:
   promote-branch-last-commit-to-prod:
     needs: [branch-and-last-commit, push-norm-branch]
     # TODO: Change to main
-    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@add-multi-arch-buildx
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@main
     with:
       source_image: brianjbayer/samplecsharpxunitselenium_${{ needs.push-norm-branch.outputs.name }}:${{ needs.branch-and-last-commit.outputs.commit }}
       target_image: brianjbayer/samplecsharpxunitselenium:${{ needs.branch-and-last-commit.outputs.commit }}
@@ -44,7 +44,7 @@ jobs:
   promote-branch-last-commit-to-prod-latest:
     needs: [branch-and-last-commit, promote-branch-last-commit-to-prod]
     # TODO: Change to main
-    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image_to_latest.yml@add-multi-arch-buildx
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image_to_latest.yml@main
     with:
       image_name: brianjbayer/samplecsharpxunitselenium
       image_tag: ${{ needs.branch-and-last-commit.outputs.commit }}
@@ -55,7 +55,7 @@ jobs:
   promote-branch-last-commit-devenv:
     needs: [branch-and-last-commit, push-norm-branch]
     # TODO: Change to main
-    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@add-multi-arch-buildx
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@main
     with:
       source_image: brianjbayer/samplecsharpxunitselenium_${{ needs.push-norm-branch.outputs.name }}_dev:${{ needs.branch-and-last-commit.outputs.commit }}
       target_image: brianjbayer/samplecsharpxunitselenium-dev:${{ needs.branch-and-last-commit.outputs.commit }}
@@ -66,7 +66,7 @@ jobs:
   promote-branch-last-commit-devenv-to-latest:
     needs: [branch-and-last-commit, promote-branch-last-commit-devenv]
     # TODO: Change to main
-    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image_to_latest.yml@add-multi-arch-buildx
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image_to_latest.yml@main
     with:
       image_name: brianjbayer/samplecsharpxunitselenium-dev
       image_tag: ${{ needs.branch-and-last-commit.outputs.commit }}

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ the tests against a
 [Selenium Standalone](https://github.com/SeleniumHQ/docker-selenium)
 container.
 
+> :apple: Apple Silicon Macs will actually run against the
+> [Seleniarm Standalone](https://github.com/seleniumhq-community/docker-seleniarm)
+> container
+
 You can view the running tests, using the included
 Virtual Network Computing (VNC) server.
 
@@ -106,11 +110,18 @@ For more information, see the Selenium Standalone Image
 2. From the project root directory, run the `dockercomposerun`
    script setting the `Browser` and `SELENIUM_IMAGE`
    environment variables to specify Firefox...
+
+   For Apple Silicon...
+   ```
+   Browser=firefox SELENIUM_IMAGE=seleniarm/standalone-firefox ValidLoginUser=tomsmith ValidLoginPass=SuperSecretPassword! ./SampleCSharpXunitSelenium/script/dockercomposerun
+   ```
+
+   For Intel...
    ```
    Browser=firefox SELENIUM_IMAGE=selenium/standalone-firefox ValidLoginUser=tomsmith ValidLoginPass=SuperSecretPassword! ./SampleCSharpXunitSelenium/script/dockercomposerun
    ```
 
-### To Run Using the Edge Standalone Container
+### To Run Using the Edge Standalone Container (Intel only)
 1. Ensure Docker is running
 2. From the project root directory, run the `dockercomposerun`
    script setting the `Browser` and `SELENIUM_IMAGE`
@@ -318,5 +329,5 @@ environment...
   ```
 
 ## Sources and Additional Information
-* The [WebDriverManager.Net](https://github.com/rosolko/WebDriverManager.Net)
 * The [Selenium Docker Images](https://github.com/SeleniumHQ/docker-selenium)
+* The [Seleniarm Docker Images](https://github.com/seleniumhq-community/docker-seleniarm)

--- a/SampleCSharpXunitSelenium/script/dockercomposerun
+++ b/SampleCSharpXunitSelenium/script/dockercomposerun
@@ -70,6 +70,10 @@ docker_compose_command='docker-compose -f docker-compose.yml '
 if [ -z ${noselenium} ]; then
   echo "...Adding Selenium Browser to Environment"
   docker_compose_command="${docker_compose_command} -f docker-compose.selenium.yml "
+  if [[ `uname -m` == "arm64" ]]; then
+    echo "...Apple Silicon Detected adding Seleniarm Browser Override to Environment"
+    docker_compose_command="${docker_compose_command} -f docker-compose.seleniarm.yml "
+  fi
 fi
 
 if [ ! -z ${ci} ]; then

--- a/docker-compose.seleniarm.yml
+++ b/docker-compose.seleniarm.yml
@@ -1,0 +1,4 @@
+﻿version: '3.4'
+services:
+  seleniumbrowser:
+    image: ${SELENIUM_IMAGE:-seleniarm/standalone-chromium:latest}


### PR DESCRIPTION
# What
This changeset adds "official" support for Apple Silicon by creating `linux/arm64` images in CI in addition to the `linux/amd64` image.  This was actually already happening since the last PR brianjbayer/SampleCSharpXunitSelenium#11.

Specifically...
* Updates multi-architecture workflows to use the `@main` branch
* Adds (automatic) support for [Seleniarm browser](https://github.com/seleniumhq-community/docker-seleniarm) image for Apple Silicon
* Update Readme about Seleniarm browser

# Why
This makes life easier for Apple Silicon based development and operations.

# Change Impact Analysis and Testing

- [x] PR CI Checks vet those changes to main branch
- [x] Merge checks will only vet those changes to main branch on merge 😦 
- [x] Vet Seleniarm support
- [x] README changes inspected on branch
