### PR TITLE
Remove TODO comments leftover from when workflows were experimental (multi-arch)

### DIFF
--- a/.github/workflows/on_pr_build_push_vet_images.yml
+++ b/.github/workflows/on_pr_build_push_vet_images.yml
@@ -28,7 +28,6 @@ jobs:
   # Build and Push Images
   buildx-and-push-branch-devenv:
     needs: [pr-norm-branch]
-    # TODO: Change to use main branch when buildx_push_image merged
     uses: brianjbayer/actions-image-cicd/.github/workflows/buildx_push_image.yml@main
     with:
       image: brianjbayer/samplecsharpxunitselenium_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}
@@ -40,7 +39,6 @@ jobs:
 
   buildx-and-push-branch-unvetted:
     needs: [pr-norm-branch]
-    # TODO: Change to use main branch when buildx_push_image merged
     uses: brianjbayer/actions-image-cicd/.github/workflows/buildx_push_image.yml@main
     with:
       image: brianjbayer/samplecsharpxunitselenium_${{ needs.pr-norm-branch.outputs.name }}_unvetted:${{ github.event.pull_request.head.sha }}
@@ -95,7 +93,6 @@ jobs:
       - vet-dependency-security
       - vet-deploy-image-e2e-tests-matrix
       - pr-norm-branch
-    # TODO: Change to use main branch when buildx_push_image merged
     uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@main
     with:
       source_image: brianjbayer/samplecsharpxunitselenium_${{ needs.pr-norm-branch.outputs.name }}_unvetted:${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/on_push_to_main_promote_to_prod.yml
+++ b/.github/workflows/on_push_to_main_promote_to_prod.yml
@@ -32,7 +32,6 @@ jobs:
 
   promote-branch-last-commit-to-prod:
     needs: [branch-and-last-commit, push-norm-branch]
-    # TODO: Change to main
     uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@main
     with:
       source_image: brianjbayer/samplecsharpxunitselenium_${{ needs.push-norm-branch.outputs.name }}:${{ needs.branch-and-last-commit.outputs.commit }}
@@ -43,7 +42,6 @@ jobs:
 
   promote-branch-last-commit-to-prod-latest:
     needs: [branch-and-last-commit, promote-branch-last-commit-to-prod]
-    # TODO: Change to main
     uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image_to_latest.yml@main
     with:
       image_name: brianjbayer/samplecsharpxunitselenium
@@ -54,7 +52,6 @@ jobs:
 
   promote-branch-last-commit-devenv:
     needs: [branch-and-last-commit, push-norm-branch]
-    # TODO: Change to main
     uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@main
     with:
       source_image: brianjbayer/samplecsharpxunitselenium_${{ needs.push-norm-branch.outputs.name }}_dev:${{ needs.branch-and-last-commit.outputs.commit }}
@@ -65,7 +62,6 @@ jobs:
 
   promote-branch-last-commit-devenv-to-latest:
     needs: [branch-and-last-commit, promote-branch-last-commit-devenv]
-    # TODO: Change to main
     uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image_to_latest.yml@main
     with:
       image_name: brianjbayer/samplecsharpxunitselenium-dev


### PR DESCRIPTION
# What
This comments-only changeset removes the `# TODO:` comments left over in the CI workflow files from when they used an "experimental" branch 
