### PR TITLE
Update Checks to use v0.2.0 of the actions-image-cicd Reusable Workflows

### DIFF
--- a/.github/workflows/on_pr_build_push_vet_images.yml
+++ b/.github/workflows/on_pr_build_push_vet_images.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: dockercomposerun linting on development environment
-        run: "BROWSERTESTS_IMAGE=${DEVENV_IMAGE} ./SampleCSharpXunitSelenium/script/dockercomposerun -n -d ./SampleCSharpXunitSelenium/script/run lint"
+        run: "BROWSERTESTS_IMAGE=${DEVENV_IMAGE} ./SampleCSharpXunitSelenium/script/dockercomposerun -do ./SampleCSharpXunitSelenium/script/run lint"
 
   vet-dependency-security:
     needs: [pr-norm-branch, buildx-and-push-branch-devenv]
@@ -66,7 +66,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: dockercomposerun security scan on development environment
-        run: "BROWSERTESTS_IMAGE=${DEVENV_IMAGE} ./SampleCSharpXunitSelenium/script/dockercomposerun -n -d ./SampleCSharpXunitSelenium/script/run secscan"
+        run: "BROWSERTESTS_IMAGE=${DEVENV_IMAGE} ./SampleCSharpXunitSelenium/script/dockercomposerun -do ./SampleCSharpXunitSelenium/script/run secscan"
 
   vet-deploy-image-e2e-tests-matrix:
     needs: [pr-norm-branch, buildx-and-push-branch-unvetted]

--- a/.github/workflows/on_pr_build_push_vet_images.yml
+++ b/.github/workflows/on_pr_build_push_vet_images.yml
@@ -1,121 +1,100 @@
-name: On PR Build Push Vet
+name: Build and Vet
 
 on:
   pull_request:
     branches:
       - main
 
-env:
-  BRANCH: ${{ github.head_ref }}
-  COMMIT: ${{ github.event.pull_request.head.sha }}
-
-# FYI...
-#  Raw Branch Name: ${{ github.head_ref }}
-#  <commit-sha>: ${{ github.event.pull_request.head.sha }}
-
-# Produced multi-architecture (linux/amd64,linux/arm64) images...
-#  1. (Always) Unvetted Image: brianjbayer/samplecsharpxunitselenium_<normalized-branch>_unvetted:<commit-sha>
-#  2. (Always) Dev Environment Image: brianjbayer/samplecsharpxunitselenium_<normalized-branch>_dev:<commit-sha>
-#  3. (If vetted) Vetted_image: brianjbayer/samplecsharpxunitselenium_<normalized-branch>:<commit-sha>
-
 jobs:
-  # Normalize the branch for image name
-  pr-norm-branch:
-    uses: brianjbayer/actions-image-cicd/.github/workflows/normalize_for_image_name.yml@main
+
+  # --- Image Names ---
+
+  image-names:
+    name: PR (Branch) Image Names
+    uses: brianjbayer/actions-image-cicd/.github/workflows/image_names.yml@v0.2.0
     with:
-      raw_name: ${{ github.head_ref }}
+      image_base_name: brianjbayer/samplecsharpxunitselenium
+      add_branch_name: true
 
-  # Build and Push Images
-  buildx-and-push-branch-devenv:
-    needs: [pr-norm-branch]
-    uses: brianjbayer/actions-image-cicd/.github/workflows/buildx_push_image.yml@main
-    with:
-      image: brianjbayer/samplecsharpxunitselenium_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}
-      buildopts: --target devenv
-      platforms: "linux/amd64,linux/arm64"
-    secrets:
-      registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
-      registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+  # --- Build and Push Images ---
 
-  buildx-and-push-branch-unvetted:
-    needs: [pr-norm-branch]
-    uses: brianjbayer/actions-image-cicd/.github/workflows/buildx_push_image.yml@main
-    with:
-      image: brianjbayer/samplecsharpxunitselenium_${{ needs.pr-norm-branch.outputs.name }}_unvetted:${{ github.event.pull_request.head.sha }}
-      platforms: "linux/amd64,linux/arm64"
-    secrets:
-      registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
-      registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-
-  # Vet Deploy Image
-  vet-code-standards:
-    needs: [pr-norm-branch, buildx-and-push-branch-devenv]
-    runs-on: ubuntu-latest
-    env:
-      DEVENV_IMAGE: brianjbayer/samplecsharpxunitselenium_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}
-    steps:
-      - uses: actions/checkout@v1
-      - name: dockercomposerun linting on development environment
-        run: "BROWSERTESTS_IMAGE=${DEVENV_IMAGE} ./SampleCSharpXunitSelenium/script/dockercomposerun -do ./SampleCSharpXunitSelenium/script/run lint"
-
-  vet-dependency-security:
-    needs: [pr-norm-branch, buildx-and-push-branch-devenv]
-    runs-on: ubuntu-latest
-    env:
-      DEVENV_IMAGE: brianjbayer/samplecsharpxunitselenium_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}
-    steps:
-      - uses: actions/checkout@v1
-      - name: dockercomposerun security scan on development environment
-        run: "BROWSERTESTS_IMAGE=${DEVENV_IMAGE} ./SampleCSharpXunitSelenium/script/dockercomposerun -do ./SampleCSharpXunitSelenium/script/run secscan"
-
-  vet-deploy-image-e2e-tests-matrix:
-    needs: [pr-norm-branch, buildx-and-push-branch-unvetted]
-    strategy:
-      fail-fast: false
-      matrix:
-        browser: [chrome, firefox, edge]
-    runs-on: ubuntu-latest
-    env:
-      UNVETTED_IMAGE: brianjbayer/samplecsharpxunitselenium_${{ needs.pr-norm-branch.outputs.name }}_unvetted:${{ github.event.pull_request.head.sha }}
-      Browser: ${{ matrix.browser }}
-      SELENIUM_IMAGE: selenium/standalone-${{ matrix.browser }}:latest
-      ValidLoginUser: ${{ secrets.ValidLoginUser }}
-      ValidLoginPass: ${{ secrets.ValidLoginPass }}
-    steps:
-      - uses: actions/checkout@v1
-      - name: dockercomposerun unvetted image
-        run: "BROWSERTESTS_IMAGE=${UNVETTED_IMAGE} ./SampleCSharpXunitSelenium/script/dockercomposerun -c"
-
-# Copy (IF) Vetted Deploy Image
-  copy-branch-vetted-deploy-image:
+  buildx-and-push-dev-image:
+    name: Build Development Image
     needs:
-      - vet-code-standards
-      - vet-dependency-security
-      - vet-deploy-image-e2e-tests-matrix
-      - pr-norm-branch
-    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@main
+      - image-names
+    uses: brianjbayer/actions-image-cicd/.github/workflows/buildx_push_image.yml@v0.2.0
     with:
-      source_image: brianjbayer/samplecsharpxunitselenium_${{ needs.pr-norm-branch.outputs.name }}_unvetted:${{ github.event.pull_request.head.sha }}
-      target_image: brianjbayer/samplecsharpxunitselenium_${{ needs.pr-norm-branch.outputs.name }}:${{ github.event.pull_request.head.sha }}
+      image: ${{ needs.image-names.outputs.dev_image }}
+      platforms: "linux/amd64,linux/arm64"
+      buildopts: --target devenv
     secrets:
       registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
       registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-  # Vet Dev Environment Image
-  vet-devenv-image-e2e-tests-matrix:
-    needs: [pr-norm-branch, buildx-and-push-branch-devenv]
-    strategy:
-      fail-fast: false
-      matrix:
-        browser: [chrome, firefox, edge]
-    runs-on: ubuntu-latest
-    env:
-      DEVENV_IMAGE: brianjbayer/samplecsharpxunitselenium_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}
-      Browser: ${{ matrix.browser }}
-      SELENIUM_IMAGE: selenium/standalone-${{ matrix.browser }}:latest
-      ValidLoginUser: ${{ secrets.ValidLoginUser }}
-      ValidLoginPass: ${{ secrets.ValidLoginPass }}
-    steps:
-      - uses: actions/checkout@v1
-      - name: dockercomposerun devenv image
-        run: "BROWSERTESTS_IMAGE=${DEVENV_IMAGE} ./SampleCSharpXunitSelenium/script/dockercomposerun -d ./SampleCSharpXunitSelenium/script/run tests"
+  buildx-and-push-unvetted-image:
+    name: Build Deployment (Unvetted) Image
+    needs:
+      - image-names
+    uses: brianjbayer/actions-image-cicd/.github/workflows/buildx_push_image.yml@v0.2.0
+    with:
+      image: ${{ needs.image-names.outputs.unvetted_image }}
+      platforms: "linux/amd64,linux/arm64"
+    secrets:
+      registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
+      registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+# --- Vet Images ---
+
+  vet-lint-and-dependency-security:
+    name: Vet Code Quality
+    needs:
+      - image-names
+      - buildx-and-push-dev-image
+    uses: brianjbayer/actions-image-cicd/.github/workflows/vet_code_standards.yml@v0.2.0
+    with:
+      lint_command: "BROWSERTESTS_IMAGE=${{ needs.image-names.outputs.dev_image }} ./SampleCSharpXunitSelenium/script/dockercomposerun -do ./SampleCSharpXunitSelenium/script/run lint"
+      dependency_security_command: "BROWSERTESTS_IMAGE=${{ needs.image-names.outputs.dev_image }} ./SampleCSharpXunitSelenium/script/dockercomposerun -do ./SampleCSharpXunitSelenium/script/run secscan"
+
+  # - End-to-End Tests -
+  vet-e2e-tests-deployment:
+    name: Vet End-to-End Tests (Deployment Image)
+    needs:
+      - image-names
+      - buildx-and-push-unvetted-image
+    uses: ./.github/workflows/run_e2e_tests.yml
+    with:
+      e2e_tests_image: ${{ needs.image-names.outputs.unvetted_image }}
+      e2e_tests_command: "./SampleCSharpXunitSelenium/script/dockercomposerun -c"
+    secrets:
+      valid_login_user: ${{ secrets.ValidLoginUser }}
+      valid_login_password: ${{ secrets.ValidLoginPass }}
+
+  # End-to-End Tests (Dev Image)
+  run-e2e-tests-development:
+    name: Run End-to-End Tests (Development Image)
+    needs:
+      - image-names
+      - buildx-and-push-dev-image
+    uses: ./.github/workflows/run_e2e_tests.yml
+    with:
+      e2e_tests_image: ${{ needs.image-names.outputs.dev_image }}
+      e2e_tests_command: "./SampleCSharpXunitSelenium/script/dockercomposerun -d ./SampleCSharpXunitSelenium/script/run tests"
+    secrets:
+      valid_login_user: ${{ secrets.ValidLoginUser }}
+      valid_login_password: ${{ secrets.ValidLoginPass }}
+
+  # --- Promote Vetted Image If It Passes ---
+
+  copy-branch-vetted-deploy-image:
+    name: Promote Vetted Deployment Image
+    needs:
+      - image-names
+      - vet-lint-and-dependency-security
+      - vet-e2e-tests-deployment
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@v0.2.0
+    with:
+      source_image: ${{ needs.image-names.outputs.unvetted_image }}
+      target_image: ${{ needs.image-names.outputs.vetted_image }}
+    secrets:
+      registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
+      registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}

--- a/.github/workflows/on_push_to_main_promote_to_prod.yml
+++ b/.github/workflows/on_push_to_main_promote_to_prod.yml
@@ -7,11 +7,11 @@ on:
 jobs:
 
   branch-and-last-commit:
-    uses: brianjbayer/actions-image-cicd/.github/workflows/get_merged_branch_last_commit.yml@main
+    uses: brianjbayer/actions-image-cicd/.github/workflows/get_merged_branch_last_commit.yml@v0.1.0
 
   push-norm-branch:
     needs: [branch-and-last-commit]
-    uses: brianjbayer/actions-image-cicd/.github/workflows/normalize_for_image_name.yml@main
+    uses: brianjbayer/actions-image-cicd/.github/workflows/normalize_for_image_name.yml@v0.1.0
     with:
       raw_name: ${{ needs.branch-and-last-commit.outputs.branch }}
 
@@ -32,7 +32,7 @@ jobs:
 
   promote-branch-last-commit-to-prod:
     needs: [branch-and-last-commit, push-norm-branch]
-    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@main
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@v0.1.0
     with:
       source_image: brianjbayer/samplecsharpxunitselenium_${{ needs.push-norm-branch.outputs.name }}:${{ needs.branch-and-last-commit.outputs.commit }}
       target_image: brianjbayer/samplecsharpxunitselenium:${{ needs.branch-and-last-commit.outputs.commit }}
@@ -42,7 +42,7 @@ jobs:
 
   promote-branch-last-commit-to-prod-latest:
     needs: [branch-and-last-commit, promote-branch-last-commit-to-prod]
-    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image_to_latest.yml@main
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image_to_latest.yml@v0.1.0
     with:
       image_name: brianjbayer/samplecsharpxunitselenium
       image_tag: ${{ needs.branch-and-last-commit.outputs.commit }}
@@ -52,7 +52,7 @@ jobs:
 
   promote-branch-last-commit-devenv:
     needs: [branch-and-last-commit, push-norm-branch]
-    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@main
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@v0.1.0
     with:
       source_image: brianjbayer/samplecsharpxunitselenium_${{ needs.push-norm-branch.outputs.name }}_dev:${{ needs.branch-and-last-commit.outputs.commit }}
       target_image: brianjbayer/samplecsharpxunitselenium-dev:${{ needs.branch-and-last-commit.outputs.commit }}
@@ -62,7 +62,7 @@ jobs:
 
   promote-branch-last-commit-devenv-to-latest:
     needs: [branch-and-last-commit, promote-branch-last-commit-devenv]
-    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image_to_latest.yml@main
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image_to_latest.yml@v0.1.0
     with:
       image_name: brianjbayer/samplecsharpxunitselenium-dev
       image_tag: ${{ needs.branch-and-last-commit.outputs.commit }}

--- a/.github/workflows/on_push_to_main_promote_to_prod.yml
+++ b/.github/workflows/on_push_to_main_promote_to_prod.yml
@@ -1,4 +1,4 @@
-name: On Merge Promote Branch Image to Prod
+name: Promote Branch Image to Production
 on:
   push:
     branches:
@@ -6,66 +6,80 @@ on:
 
 jobs:
 
+  # --- Image Names ---
+
   branch-and-last-commit:
-    uses: brianjbayer/actions-image-cicd/.github/workflows/get_merged_branch_last_commit.yml@v0.1.0
+    name: Merged Branch and Last Commit
+    uses: brianjbayer/actions-image-cicd/.github/workflows/get_merged_branch_last_commit.yml@v0.2.0
 
-  push-norm-branch:
-    needs: [branch-and-last-commit]
-    uses: brianjbayer/actions-image-cicd/.github/workflows/normalize_for_image_name.yml@v0.1.0
+  merged-image-names:
+    name: Merged (Branch) Image Names
+    needs:
+      - branch-and-last-commit
+    uses: brianjbayer/actions-image-cicd/.github/workflows/image_names.yml@v0.2.0
     with:
-      raw_name: ${{ needs.branch-and-last-commit.outputs.branch }}
+      add_branch_name: true
+      branch_name: ${{ needs.branch-and-last-commit.outputs.branch }}
+      tag: ${{ needs.branch-and-last-commit.outputs.commit }}
 
-  branch-and-last-commit-merged-info:
-    needs: [branch-and-last-commit, push-norm-branch]
-    runs-on: ubuntu-latest
-    env:
-      BRANCH_LAST_COMMIT: ${{ needs.branch-and-last-commit.outputs.commit }}
-      BRANCH: ${{ needs.branch-and-last-commit.outputs.branch }}
-      NORM_BRANCH: ${{ needs.push-norm-branch.outputs.name }}
-    steps:
-      - name: Output last commit of merged branch env var
-        run: echo "BRANCH_LAST_COMMIT=[${BRANCH_LAST_COMMIT}]"
-      - name: Output merged branch env var
-        run: echo "BRANCH=[${BRANCH}]"
-      - name: Output normalized merged branch env var
-        run: echo "NORM_BRANCH=[${NORM_BRANCH}]"
-
-  promote-branch-last-commit-to-prod:
-    needs: [branch-and-last-commit, push-norm-branch]
-    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@v0.1.0
+  production-image-names:
+    name: Production Image Names
+    needs:
+      - branch-and-last-commit
+    uses: brianjbayer/actions-image-cicd/.github/workflows/image_names.yml@v0.2.0
     with:
-      source_image: brianjbayer/samplecsharpxunitselenium_${{ needs.push-norm-branch.outputs.name }}:${{ needs.branch-and-last-commit.outputs.commit }}
-      target_image: brianjbayer/samplecsharpxunitselenium:${{ needs.branch-and-last-commit.outputs.commit }}
+      tag: ${{ needs.branch-and-last-commit.outputs.commit }}
+
+  # --- Promote Production Images ---
+
+  # Promote Deployment Image
+  promote-merged-deploy-image:
+    name: Promote Merged Deployment Image to Production
+    needs:
+      - merged-image-names
+      - production-image-names
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@v0.2.0
+    with:
+      source_image: ${{ needs.merged-image-names.outputs.vetted_image }}
+      target_image: ${{ needs.production-image-names.outputs.vetted_image }}
     secrets:
       registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
       registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-  promote-branch-last-commit-to-prod-latest:
-    needs: [branch-and-last-commit, promote-branch-last-commit-to-prod]
-    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image_to_latest.yml@v0.1.0
+  promote-merged-deploy-image-to-latest:
+    name: Promote Latest Deployment Image
+    needs:
+      - production-image-names
+      - promote-merged-deploy-image
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image_to_latest.yml@v0.2.0
     with:
-      image_name: brianjbayer/samplecsharpxunitselenium
-      image_tag: ${{ needs.branch-and-last-commit.outputs.commit }}
+      image: ${{ needs.production-image-names.outputs.vetted_image }}
     secrets:
       registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
       registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-  promote-branch-last-commit-devenv:
-    needs: [branch-and-last-commit, push-norm-branch]
-    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@v0.1.0
+  # Promote Development Image
+  promote-merged-dev-image:
+    name: Promote Merged Development Image
+    needs:
+      - merged-image-names
+      - production-image-names
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@v0.2.0
     with:
-      source_image: brianjbayer/samplecsharpxunitselenium_${{ needs.push-norm-branch.outputs.name }}_dev:${{ needs.branch-and-last-commit.outputs.commit }}
-      target_image: brianjbayer/samplecsharpxunitselenium-dev:${{ needs.branch-and-last-commit.outputs.commit }}
+      source_image: ${{ needs.merged-image-names.outputs.dev_image }}
+      target_image: ${{ needs.production-image-names.outputs.dev_image }}
     secrets:
       registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
       registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-  promote-branch-last-commit-devenv-to-latest:
-    needs: [branch-and-last-commit, promote-branch-last-commit-devenv]
-    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image_to_latest.yml@v0.1.0
+  promote-merged-dev-image-to-latest:
+    name: Promote Latest Development Image
+    needs:
+      - production-image-names
+      - promote-merged-dev-image
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image_to_latest.yml@v0.2.0
     with:
-      image_name: brianjbayer/samplecsharpxunitselenium-dev
-      image_tag: ${{ needs.branch-and-last-commit.outputs.commit }}
+      image: ${{ needs.production-image-names.outputs.dev_image }}
     secrets:
       registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
       registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}

--- a/.github/workflows/run_e2e_tests.yml
+++ b/.github/workflows/run_e2e_tests.yml
@@ -1,0 +1,48 @@
+name: Run End-to-End Tests
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        description: "The type of runner for this workflow (Default: ubuntu-latest)"
+        required: false
+        type: string
+        default: ubuntu-latest
+      e2e_tests_image:
+        description: "The End-to-End tests image to run"
+        required: true
+        type: string
+      e2e_tests_command:
+        description: "The End-to-End tests image to run"
+        required: true
+        type: string
+
+    secrets:
+      valid_login_user:
+        description: The username for the test login
+        required: true
+      valid_login_password:
+        description: The password for the test login
+        required: true
+
+jobs:
+  e2e-tests:
+    name: End-to-End Tests
+    runs-on: ${{ inputs.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # MS Edge is currently not supported per brianjbayer/sample-login-capybara-rspec#97
+        browser: [chrome, firefox, edge]
+        # browser: [chrome, firefox]
+    env:
+      BROWSERTESTS_IMAGE: ${{ inputs.e2e_tests_image }}
+      Browser: ${{ matrix.browser }}
+      SELENIUM_IMAGE: selenium/standalone-${{ matrix.browser }}:latest
+      # BASE_URL: "https://the-internet.herokuapp.com"
+      ValidLoginUser: ${{ secrets.valid_login_user }}
+      ValidLoginPass: ${{ secrets.valid_login_password }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: dockercomposerun e2e tests
+        run: ${{ inputs.e2e_tests_command }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 # Base Image is the builder stage since it is an SDK
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS builder
+ARG BASE_IMAGE=mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim
+FROM --platform=$BUILDPLATFORM ${BASE_IMAGE} AS sdk
 
 # Dev Environment Stage
-FROM builder AS devenv
+FROM sdk AS devenv
 # At least install vim (git is already present)
 RUN apt-get update && apt-get --no-install-recommends -y install vim
 # ASSUME project source is volume mounted into the container at path /app
@@ -10,7 +11,7 @@ WORKDIR /app
 CMD bash
 
 # Deploy Stage
-FROM builder AS deploy
+FROM sdk AS deploy
 # TODO is this needed still - must run as root
 RUN sed -i 's/SECLEVEL=2/SECLEVEL=1/g' /etc/ssl/openssl.cnf
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,17 @@
 # Base Image is the builder stage since it is an SDK
 ARG BASE_IMAGE=mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim
-FROM --platform=$BUILDPLATFORM ${BASE_IMAGE} AS sdk
+FROM ${BASE_IMAGE} AS sdk
 
 # Dev Environment Stage
 FROM sdk AS devenv
 # At least install vim (git is already present)
 RUN apt-get update && apt-get --no-install-recommends -y install vim
+
 # ASSUME project source is volume mounted into the container at path /app
 WORKDIR /app
-CMD bash
+
+# Start devenv in (command line) shell
+CMD ["bash"]
 
 # Deploy Stage
 FROM sdk AS deploy
@@ -21,7 +24,9 @@ USER deployer
 
 # Copy the source to /app
 COPY --chown=deployer . /app/
+
 # Change to the tests subproject directory
 WORKDIR /app/SampleCSharpXunitSelenium
+
 # Overridable: Run the tests
-CMD ./script/run tests
+CMD ["./script/run", "tests"]

--- a/SampleCSharpXunitSelenium/script/dockercomposerun
+++ b/SampleCSharpXunitSelenium/script/dockercomposerun
@@ -1,128 +1,89 @@
 #!/bin/sh
-# ----------------------------------------------------------------------
-# This script runs the project docker-compose framework.
-#
-# - The arguments to this script are passed to the browsertests service
-#   as command override
-#
-# - Any environment variables set when calling this script are passed
-#   through to the docker-compose framework
-#   (e.g. configuration other than the defaults)
-#
-# OPTIONS:
-# -c: Use the docker-compose CI environment with BROWSERTESTS_IMAGE
-# -d: Use the docker-compose Dev environment with BROWSERTESTS_IMAGE
-# -n: No Selenium browser in the docker-compose environment
-# ----------------------------------------------------------------------
-
-usage() {
-  echo "Usage: $0 [-cdn] [CMD]"
-}
-
-err_exit() {
-  local err_msg="$1"
-  local err_code=$2
-  echo "${err_msg}  --  Exit:[${err_code}]" 1>&2
-  usage
-  exit $err_code
-}
 
 # Exit script on any errors
 set -e
 
+usage() {
+  cat << USAGE
+Usage: $0 [-cdho] [CMD]
+
+This script orchestrates 'docker compose run browsertests' using the docker compose framework
+  * Arguments are passed to the app service as the CMD (entrypoint)
+  * Environment variables override app and framework defaults
+
+OPTIONS: (in override order)
+  -o: Run only the browsertests service (no Selenium Browser)
+  -d: Run the docker-compose Dev environment
+  -c: Run the docker-compose CI environment (must specify BROWSERTESTS_IMAGE)
+USAGE
+}
+
+err_exit() {
+  err_code=$1
+  err_msg="$2"
+  echo "${err_msg}  --  Exit:[${err_code}]" 1>&2
+  exit $err_code
+}
+
 # Handle options
-while getopts ":cdn" options; do
+while getopts ":cdho" options; do
   case "${options}" in
     c)
-      echo "CI Environment"
-      ci=true
+      ci=1
       ;;
     d)
-      echo "Development Environment"
-      devenv=true
+      devenv=1
       ;;
-    n)
-      echo "No Selenium"
-      noselenium=true
+    h)
+      usage ; exit
+      ;;
+    o)
+      browsertests_only=1
       ;;
     \?)
-    err_exit "Invalid Option: -$OPTARG" 1
+      usage
+      err_exit 1 "Invalid Option: -$OPTARG"
       ;;
   esac
 done
 shift $((OPTIND-1))
 
-echo ''
-echo "ENVIRONMENT VARIABLES..."
-env
-echo ''
+echo "DOCKER VERSION: [`docker --version`]"
+docker_compose_command='docker compose -f docker-compose.yml '
 
-echo 'DOCKER VERSION...'
-docker --version
-docker-compose --version
-echo ''
-
-# Override docker compose environments
-echo 'DOCKER-COMPOSE COMMAND...'
-docker_compose_command='docker-compose -f docker-compose.yml '
-
-# Unless the no selenium option is set, use Selenium browser
-if [ -z ${noselenium} ]; then
-  echo "...Adding Selenium Browser to Environment"
+if [ -z ${browsertests_only} ] ; then
   docker_compose_command="${docker_compose_command} -f docker-compose.selenium.yml "
-  if [[ `uname -m` == "arm64" ]]; then
-    echo "...Apple Silicon Detected adding Seleniarm Browser Override to Environment"
-    docker_compose_command="${docker_compose_command} -f docker-compose.seleniarm.yml "
-  fi
+  [[ `uname -m` == "arm64" ]] && docker_compose_command="${docker_compose_command} -f docker-compose.seleniarm.yml "
 fi
 
-if [ ! -z ${ci} ]; then
-  echo "...Using CI Environment with Image [${BROWSERTESTS_IMAGE}]"
-  docker_compose_command="${docker_compose_command} -f docker-compose.ci.yml "
-fi
+[ ! -z ${devenv} ] && docker_compose_command="${docker_compose_command} -f docker-compose.dev.yml "
+[ ! -z ${ci} ] && docker_compose_command="${docker_compose_command} -f docker-compose.ci.yml "
 
-if [ ! -z ${devenv} ]; then
-  echo "...Using Development Environment with Image [${BROWSERTESTS_IMAGE}]"
-  docker_compose_command="${docker_compose_command} -f docker-compose.dev.yml "
-fi
-echo "...COMMAND: [${docker_compose_command}]"
-echo ''
+# Default is to run the browsertests, but must specify --service-ports
+# (by default docker compose run does not expose host ports)
+run_command='run --rm --service-ports browsertests '
 
-echo 'DOCKER-COMPOSE CONFIGURATION...'
+docker_compose_run_command="${docker_compose_command} ${run_command}"
+echo "DOCKER COMPOSE RUN COMMAND: [${docker_compose_run_command}]"
+
+echo 'DOCKER COMPOSE CONFIGURATION...'
 $docker_compose_command config
-echo ''
 
-echo 'DOCKER-COMPOSE PULLING...'
-set +e
-$docker_compose_command pull
-echo '...Allowing pull errors (for local images)'
-set -e
-echo ''
+echo 'DOCKER COMPOSE PULLING...'
+set +e ; $docker_compose_command pull ; set -e
 
-echo 'DOCKER IMAGES...'
-docker images
-echo ''
-
-echo "DOCKER-COMPOSE RUNNING [$@]..."
+echo "DOCKER COMPOSE RUNNING [${docker_compose_run_command}] [$@]..."
 # Allow to fail but catch return code
 set +e
-$docker_compose_command run browsertests "$@"
+${docker_compose_run_command} "$@"
 run_return_code=$?
-# NOTE return code must be caught before any other command
 set -e
-echo ''
 
-if [ $run_return_code -eq 0 ]; then
-    run_disposition='PASSED'
-else
-    run_disposition='FAILED'
-fi
-echo "...RUN [${run_disposition}] WITH RETURN CODE [${run_return_code}]"
-echo ''
+run_disposition='SUCCESS' ; [ $run_return_code -eq 0 ] || run_disposition='FAIL'
+echo "DOCKER COMPOSE RUN [${run_disposition}] WITH RETURN CODE [${run_return_code}]"
 
 echo 'DOCKER-COMPOSE DOWN...'
 $docker_compose_command down
-echo ''
 
-echo "EXITING WITH ${run_disposition} RUN RETURN CODE ${run_return_code}"
+echo "EXIT: ${run_disposition} [${run_return_code}]"
 exit $run_return_code

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,4 +1,3 @@
-version: '3.4'
 services:
   browsertests:
   # Override production image but no volume mount like dev

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,4 +1,3 @@
-version: '3.4'
 services:
   browsertests:
     image: ${BROWSERTESTS_IMAGE:-brianjbayer/samplecsharpxunitselenium-dev:latest}

--- a/docker-compose.seleniarm.yml
+++ b/docker-compose.seleniarm.yml
@@ -1,4 +1,3 @@
-﻿version: '3.4'
-services:
+﻿services:
   seleniumbrowser:
     image: ${SELENIUM_IMAGE:-seleniarm/standalone-chromium:latest}

--- a/docker-compose.selenium.yml
+++ b/docker-compose.selenium.yml
@@ -1,5 +1,4 @@
-﻿version: '3.4'
-services:
+﻿services:
   browsertests:
     environment:
       - Browser=${Browser:-chrome}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.4'
 services:
   browsertests:
     image: brianjbayer/samplecsharpxunitselenium:${BROWSERTESTS_TAG:-latest}


### PR DESCRIPTION
# What and Why
This changeset updates the Continuous Integration (CI) *Checks* used by this project to use version `v0.2.0` of the [`actions-image-cicd`](https://github.com/brianjbayer/actions-image-cicd) Reusable Workflows to reduce lines of configuration and follow current standards.  Other miscellaneous updates and corrections were also made.

# Change Impact Analysis and Testing
It is the Checks themselves that are the primary elements under test, therefore successful execution of both the PR and Merge Checks will sufficiently verify these changes.

In addition, this PR was used in the development and testing of `v0.2.0`.