### PR TITLE
Fix Merge Checks - Must provide normalized container repository name

### DIFF
--- a/.github/workflows/on_push_to_main_promote_to_prod.yml
+++ b/.github/workflows/on_push_to_main_promote_to_prod.yml
@@ -18,6 +18,7 @@ jobs:
       - branch-and-last-commit
     uses: brianjbayer/actions-image-cicd/.github/workflows/image_names.yml@v0.2.0
     with:
+      image_base_name: brianjbayer/samplecsharpxunitselenium
       add_branch_name: true
       branch_name: ${{ needs.branch-and-last-commit.outputs.branch }}
       tag: ${{ needs.branch-and-last-commit.outputs.commit }}
@@ -28,6 +29,7 @@ jobs:
       - branch-and-last-commit
     uses: brianjbayer/actions-image-cicd/.github/workflows/image_names.yml@v0.2.0
     with:
+      image_base_name: brianjbayer/samplecsharpxunitselenium
       tag: ${{ needs.branch-and-last-commit.outputs.commit }}
 
   # --- Promote Production Images ---


### PR DESCRIPTION
# What
This fix changeset restores providing a normalized (lowercase) name for the project's container repositories as C# standard of PascalCase is not supported for docker image names.

# Why
This should fix the merge checks

# Change Impact Analysis and Testing
These changes can only be tested on merge, but the input and values were copied from the originating build of the images in the PR Checks.
