### PR TITLE
Deprecate the `seleniarm/standalone-chromium` image for `selenium/standalone-chromium`

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,10 +264,10 @@ container.
 
 #### Running Just the Development Environment
 To run the development environment on its own in the docker-compose
-environment **without a Selenium browser**, use the `-n` option for
+environment **without a Selenium browser**, use the `-o` option for
 no Selenium and the `-d` option for the development environment...
 ```
-ValidLoginUser=tomsmith ValidLoginPass=SuperSecretPassword! ./SampleCSharpXunitSelenium/script/dockercomposerun -n -d
+ValidLoginUser=tomsmith ValidLoginPass=SuperSecretPassword! ./SampleCSharpXunitSelenium/script/dockercomposerun -o -d
 ```
 
 #### Building Your Own Development Environment Image
@@ -284,7 +284,7 @@ You can also build and run your own development environment image.
    (or other browser containers) and specify your development
    environment image with `BROWSERTESTS_IMAGE`
    ```
-   BROWSERTESTS_IMAGE=browsertests-dev ValidLoginUser=tomsmith ValidLoginPass=SuperSecretPassword! ./SampleCSharpXunitSelenium/script/dockercomposerun -n -d
+   BROWSERTESTS_IMAGE=browsertests-dev ValidLoginUser=tomsmith ValidLoginPass=SuperSecretPassword! ./SampleCSharpXunitSelenium/script/dockercomposerun -o -d
    ```
 
 #### Specifying the Source Code Location

--- a/README.md
+++ b/README.md
@@ -49,10 +49,6 @@ the tests against a
 [Selenium Standalone](https://github.com/SeleniumHQ/docker-selenium)
 container.
 
-> :apple: Apple Silicon Macs will actually run against the
-> [Seleniarm Standalone](https://github.com/seleniumhq-community/docker-seleniarm)
-> container
-
 You can view the running tests, using the included
 Virtual Network Computing (VNC) server.
 
@@ -96,7 +92,7 @@ You can use either a VNC client or a web browser to view the tests.
 For more information, see the Selenium Standalone Image
 [VNC documentation](https://github.com/SeleniumHQ/docker-selenium#debugging)
 
-### To Run Using the Default Chrome Standalone Container
+### To Run Using the Default Chromium Standalone Container
 1. Ensure Docker is running
 2. From the project root directory, run the `dockercomposerun`
    script with the defaults...
@@ -110,13 +106,6 @@ For more information, see the Selenium Standalone Image
 2. From the project root directory, run the `dockercomposerun`
    script setting the `Browser` and `SELENIUM_IMAGE`
    environment variables to specify Firefox...
-
-   For Apple Silicon...
-   ```
-   Browser=firefox SELENIUM_IMAGE=seleniarm/standalone-firefox ValidLoginUser=tomsmith ValidLoginPass=SuperSecretPassword! ./SampleCSharpXunitSelenium/script/dockercomposerun
-   ```
-
-   For Intel...
    ```
    Browser=firefox SELENIUM_IMAGE=selenium/standalone-firefox ValidLoginUser=tomsmith ValidLoginPass=SuperSecretPassword! ./SampleCSharpXunitSelenium/script/dockercomposerun
    ```
@@ -330,4 +319,3 @@ environment...
 
 ## Sources and Additional Information
 * The [Selenium Docker Images](https://github.com/SeleniumHQ/docker-selenium)
-* The [Seleniarm Docker Images](https://github.com/seleniumhq-community/docker-seleniarm)

--- a/SampleCSharpXunitSelenium/SampleCSharpXunitSelenium.csproj
+++ b/SampleCSharpXunitSelenium/SampleCSharpXunitSelenium.csproj
@@ -5,22 +5,20 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.2"/>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0"/>
-    <PackageReference Include="Selenium.WebDriver" Version="4.15.0"/>
-    <PackageReference Include="Selenium.Support" Version="4.15.0"/>
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.24.0" />
+    <PackageReference Include="Selenium.Support" Version="4.24.0" />
     <!-- The following are transitive packages explicitly included to avoid transitive CVEs   -->
     <!-- Ideally these should be removed if/when the transitive vulnerabilities are addressed -->
-    <!-- <PackageReference Include="Newtonsoft.Json" Version="13.0.1" /> -->
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Tests\"/>

--- a/SampleCSharpXunitSelenium/script/dockercomposerun
+++ b/SampleCSharpXunitSelenium/script/dockercomposerun
@@ -51,10 +51,7 @@ shift $((OPTIND-1))
 echo "DOCKER VERSION: [`docker --version`]"
 docker_compose_command='docker compose -f docker-compose.yml '
 
-if [ -z ${browsertests_only} ] ; then
-  docker_compose_command="${docker_compose_command} -f docker-compose.selenium.yml "
-  [[ `uname -m` == "arm64" ]] && docker_compose_command="${docker_compose_command} -f docker-compose.seleniarm.yml "
-fi
+[ -z ${browsertests_only} ] && docker_compose_command="${docker_compose_command} -f docker-compose.selenium.yml "
 
 [ ! -z ${devenv} ] && docker_compose_command="${docker_compose_command} -f docker-compose.dev.yml "
 [ ! -z ${ci} ] && docker_compose_command="${docker_compose_command} -f docker-compose.ci.yml "

--- a/docker-compose.seleniarm.yml
+++ b/docker-compose.seleniarm.yml
@@ -1,3 +1,0 @@
-﻿services:
-  seleniumbrowser:
-    image: ${SELENIUM_IMAGE:-seleniarm/standalone-chromium:latest}

--- a/docker-compose.selenium.yml
+++ b/docker-compose.selenium.yml
@@ -9,7 +9,8 @@
       - seleniumbrowser
 
   seleniumbrowser:
-    image: ${SELENIUM_IMAGE:-selenium/standalone-chrome:latest}
+    # The selenium/standalone-chromium image is multiplatform (arm64)
+    image: ${SELENIUM_IMAGE:-selenium/standalone-chromium:latest}
     container_name: ${SELENIUM_HOSTNAME:-selenium-browser}
     shm_size: 2gb
     ports:


### PR DESCRIPTION
# What
The forked `seleniarm/standalone-chromium` image has been deprecated and merged into the main `selenium` project so now the `selenium/standalone-chromium` image is multiplatform (supports `arm64`).  This changeset switches to the `selenium/standalone-chromium` image and deprecates `seleniarm/standalone-chromium` in the docker compose framework.

# Why
This ensures that the chrome browser used in the tests remains current.

# Change Impact Analysis and Testing

- [x] Successful PR Checks verifies changed behavior and no regressions
- [x] Local execution on Apple Silicon verifies `arm64`
- [x] Inspection of rendered changed documentation on branch verifies correctness
